### PR TITLE
FIX(design): Load fonts from SCSS instead of HTML document head

### DIFF
--- a/client/index.scss
+++ b/client/index.scss
@@ -1,3 +1,8 @@
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro');
+@import url('https://fonts.googleapis.com/css?family=Raleway:300,400,500,700,800');
+
+$slydv-turquoise: #4ecdc4;
+
 @mixin smallcaps($size) {
   font-size: $size;
   letter-spacing: 1pt;
@@ -13,10 +18,10 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
 
   a {
-    color: #4ecdc4;
+    color: $slydv-turquoise;
     text-decoration: none;
     //black
     //color: #fff !important;
@@ -58,7 +63,7 @@ body {
 }
 
 .markdown-speaker-container{
-  
+
 }
 
 // --------------- Flexbox Default Styles --------------
@@ -265,7 +270,7 @@ header.global {
   background-repeat: repeat;
   border: 0;
   border-radius: 0;
-  border-top: 10px solid #4ecdc4;
+  border-top: 10px solid $slydv-turquoise;
   color: #fff;
   display: flex;
   flex-direction: column;
@@ -470,7 +475,9 @@ header.global {
   .nameplate {
     color: #666;
     display: inline-block;
+    font-family: Raleway, 'Source Sans Pro', sans-serif;
     font-weight: bold;
+    letter-spacing: 4px;
     margin: 0;
     padding: 18px 0;
     text-decoration: none;
@@ -566,7 +573,7 @@ div.slide-view-live.has-footer > #main{
   height: 100vh;
   width: 98%;
   background-color: #30333A;
-  color: #4ecdc4;
+  color: $slydv-turquoise;
   padding: 10px 5px;
   border: 1px solid #ccc;
   display: flex;
@@ -608,7 +615,6 @@ div.slide-view-live.has-footer > #main{
     }
   }//end .remote-speaker-notes
 }//end .remote-container
-
 
 .runkit-container{
   overflow: auto;

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,6 @@
     <meta charset='utf-8'>
     <meta name='viewport' content='width=device-width initial-scale=1.0'>
     <title>SlyDv</title>
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700,700i|Raleway:300,400,500,700,800" rel="stylesheet">
     <!--runkit-->
     <script src='https://embed.runkit.com'></script>
     <!--Deque CSS-->


### PR DESCRIPTION
Also add letterspacing to the nameplate in the nav bar, and set the default body font.

Closes #196. 🔠