### PR TITLE
DOCS(slide): Tint nonrendering title field and add tooltip

### DIFF
--- a/client/components/EditSlideForm.jsx
+++ b/client/components/EditSlideForm.jsx
@@ -208,14 +208,28 @@ class EditSlideForm extends Component {
     if (this.state.errorType) {
       if (this.state.errorType === 'view-before-save') {
         errorContinue = <Link to={`/decks/${this.props.deck.id}/static`}>Or discard your changes and preview anyway?</Link>;
-      } {/* else {
+      } { /* else {
         errorContinue = (<Link
           onClick={this.handleNewClickFromErrorToast}
           to={this.props.match.url}
-        >Or create a new slide anyway?</Link>);*/
+        >Or create a new slide anyway?</Link>); */
       }
     }
-    const titleVisibility = this.state.singleSlide.template === 'columns-header' ? 'visible-title' : 'hidden-title';
+    let titleVisibility;
+    let titleTooltip;
+    if (this.state.singleSlide.template === 'columns-header') {
+      titleVisibility = 'visible-title';
+    } else {
+      titleVisibility = 'hidden-title';
+      titleTooltip = (
+        <div className="dqpl-help-button-wrap">
+          <button className="dqpl-help-button" type="button" aria-label="Slide title help" data-help-text="This template does not render the contents of the title field, but you will still see this title on the deck overview. To add a visible title to this slide, include a Markdown heading within the first text field." aria-describedby="title-tooltip-label">
+            <div className="fa fa-question-circle" aria-hidden="true" />
+          </button>
+          <div className="dqpl-tooltip" role="tooltip" id="title-tooltip-label">This template does not render the contents of the title field, but you will still see this title on the deck overview. To add a visible title to this slide, include a Markdown heading within the first text field.</div>
+        </div>
+      );
+    }
 
     return (
       <DocumentTitle title="Edit Slide | SlyDv">
@@ -278,12 +292,7 @@ class EditSlideForm extends Component {
               <label className="dqpl-label" htmlFor="title" id="title-label">Title</label>
               <div className="dqpl-field-help">
                 <input className="dqpl-text-input" id="title" type="text" aria-labelledby="title-label" value={this.state.singleSlide.title} />
-                <div className="dqpl-help-button-wrap">
-                  <button className="dqpl-help-button" type="button" aria-label="Slide title help" data-help-text="This template does not render the contents of the title field, but you will still see this title on the deck overview. To add a visible title to this slide, include a Markdown heading within the first text field." aria-describedby="title-tooltip-label">
-                    <div className="fa fa-question-circle" aria-hidden="true" />
-                  </button>
-                  <div className="dqpl-tooltip" role="tooltip" id="title-tooltip-label">This template does not render the contents of the title field, but you will still see this title on the deck overview. To add a visible title to this slide, include a Markdown heading within the first text field.</div>
-                </div>
+                {titleTooltip}
               </div>
             </div>
 

--- a/client/components/EditSlideForm.jsx
+++ b/client/components/EditSlideForm.jsx
@@ -51,6 +51,10 @@ class EditSlideForm extends Component {
           { singleSlide: newSingleSlideAction.singleSlide }));
         return this.props.getDeck(newSingleSlideAction.singleSlide.deckId);
       });
+
+    // Refresh Deque JS whenever the page changes, to activate the title tooltip.
+    const dqplEvt = new Event('dqpl:ready');
+    document.dispatchEvent(dqplEvt);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -218,7 +222,7 @@ class EditSlideForm extends Component {
         <div className="edit-slide-form">
           <h1>Edit Slide</h1>
 
-          <p className="instructions"><em>All text fields on this form accept <a href="https://guides.github.com/features/mastering-markdown/">GitHub-flavored Markdown</a>.</em></p>
+          <p className="instructions"><em>All text fields on this form { this.state.singleSlide.template === 'repl' ? 'except “Code”' : null } accept <a href="https://guides.github.com/features/mastering-markdown/">GitHub-flavored Markdown</a>.</em></p>
 
           {/* positionInDeck -----------------------------------------*/
             this.props.deck && this.props.deck.slides
@@ -271,12 +275,16 @@ class EditSlideForm extends Component {
 
             {/* title - conditional label ------------------------------------*/}
             <div className={`dqpl-field-wrap ${titleVisibility}`}>
-              <label className="dqpl-label" htmlFor="title" id="title-label">Title
-              <button className="dqpl-help-button title-tip" type="button" aria-label="First name help" data-help-text="Note: The contents of this title field are not displayed on slides using this template, but it will be used as the slide title on the deck overview page.">
- -                <div className="fa fa-question-circle" aria-hidden="true" />
- -              </button>
-              </label>
-              <input className="dqpl-text-input" type="text" id="title" value={this.state.singleSlide.title} onChange={this.handleChange} aria-labelledby="title-label" />
+              <label className="dqpl-label" htmlFor="title" id="title-label">Title</label>
+              <div className="dqpl-field-help">
+                <input className="dqpl-text-input" id="title" type="text" aria-labelledby="title-label" value={this.state.singleSlide.title} />
+                <div className="dqpl-help-button-wrap">
+                  <button className="dqpl-help-button" type="button" aria-label="Slide title help" data-help-text="This template does not render the contents of the title field, but you will still see this title on the deck overview. To add a visible title to this slide, include a Markdown heading within the first text field." aria-describedby="title-tooltip-label">
+                    <div className="fa fa-question-circle" aria-hidden="true" />
+                  </button>
+                  <div className="dqpl-tooltip" role="tooltip" id="title-tooltip-label">This template does not render the contents of the title field, but you will still see this title on the deck overview. To add a visible title to this slide, include a Markdown heading within the first text field.</div>
+                </div>
+              </div>
             </div>
 
             {/* firstText --------------------------------*/}

--- a/client/components/EditSlideForm.jsx
+++ b/client/components/EditSlideForm.jsx
@@ -271,7 +271,11 @@ class EditSlideForm extends Component {
 
             {/* title - conditional label ------------------------------------*/}
             <div className={`dqpl-field-wrap ${titleVisibility}`}>
-              <label className="dqpl-label" htmlFor="title" id="title-label">Title</label>
+              <label className="dqpl-label" htmlFor="title" id="title-label">Title
+              <button className="dqpl-help-button title-tip" type="button" aria-label="First name help" data-help-text="Note: The contents of this title field are not displayed on slides using this template, but it will be used as the slide title on the deck overview page.">
+ -                <div className="fa fa-question-circle" aria-hidden="true" />
+ -              </button>
+              </label>
               <input className="dqpl-text-input" type="text" id="title" value={this.state.singleSlide.title} onChange={this.handleChange} aria-labelledby="title-label" />
             </div>
 

--- a/client/index.scss
+++ b/client/index.scss
@@ -3,6 +3,7 @@
 
 $slydv-turquoise: #4ecdc4;
 $slydv-teal: #099;
+$inactive-field: #bddede;
 
 @mixin smallcaps($size) {
   font-size: $size;
@@ -1545,13 +1546,12 @@ Description:  Clean, Swiss typography with no frills.
 
 }
 
-
-
-
-
-
-
 // --------------------------- END THEMES -------------------
+.dqpl-textarea {
+  height: 7.5em;
+  max-width: 100%;
+  width: 49%;
+}
 
 .dqpl-toast-error {
   a {
@@ -1572,5 +1572,11 @@ Description:  Clean, Swiss typography with no frills.
       bottom: 9vh;
       right: 20px;
     }
+  }
+}
+
+.hidden-title {
+  input {
+    background-color: $inactive-field;
   }
 }


### PR DESCRIPTION
All slide edit forms now show the title field, regardless of which template is chosen. But on templates where the field won't actually be rendered, the field background is tinted, and there is a tooltip explaining that it won't be displayed.

Closes #200.